### PR TITLE
rails_xss compatability, add gemspec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,22 @@
+PATH
+  remote: .
+  specs:
+    cssmin (1.0.3)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    json (1.8.1)
+    minitest (5.2.2)
+    rake (10.1.1)
+    rdoc (4.1.1)
+      json (~> 1.4)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  cssmin!
+  minitest
+  rake
+  rdoc

--- a/Rakefile.rb
+++ b/Rakefile.rb
@@ -1,56 +1,6 @@
-#--
-# Copyright (c) 2008 Ryan Grove <ryan@wonko.com>
-# All rights reserved.
-#
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions are met:
-#
-#   * Redistributions of source code must retain the above copyright notice,
-#     this list of conditions and the following disclaimer.
-#   * Redistributions in binary form must reproduce the above copyright notice,
-#     this list of conditions and the following disclaimer in the documentation
-#     and/or other materials provided with the distribution.
-#   * Neither the name of this project nor the names of its contributors may be
-#     used to endorse or promote products derived from this software without
-#     specific prior written permission.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
-# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-#++
-
 require 'rubygems'
-require 'rubygems/package_task'
 require 'rdoc/task'
 require 'rake/testtask'
-
-gemspec = Gem::Specification.new do |s|
-  s.name     = 'cssmin'
-  s.version  = '1.0.3'
-  s.author   = 'Ryan Grove'
-  s.email    = 'ryan@wonko.com'
-  s.homepage = 'https://github.com/rgrove/cssmin/'
-  s.platform = Gem::Platform::RUBY
-  s.summary  = 'Ruby library for minifying CSS.'
-  s.description  = 'Ruby library for minifying CSS. Inspired by cssmin.js and YUI Compressor.'
-
-  s.files        = FileList['{lib}/**/*', 'HISTORY.md', 'LICENSE'].to_a
-  s.require_path = 'lib'
-  s.has_rdoc     = true
-
-  s.required_ruby_version = '>= 1.8.6'
-end
-
-Gem::PackageTask.new(gemspec) do |p|
-  p.need_tar_gz = true
-end
 
 RDoc::Task.new do |rd|
   rd.main     = 'CSSMin'

--- a/cssmin.gemspec
+++ b/cssmin.gemspec
@@ -1,0 +1,24 @@
+# coding: utf-8
+
+Gem::Specification.new do |s|
+  s.name     = 'cssmin'
+  s.version  = '1.0.3'
+  s.author   = 'Ryan Grove'
+  s.email    = 'ryan@wonko.com'
+  s.homepage = 'https://github.com/rgrove/cssmin/'
+  s.platform = Gem::Platform::RUBY
+  s.summary  = 'Ruby library for minifying CSS.'
+  s.description  = 'Ruby library for minifying CSS. Inspired by cssmin.js and YUI Compressor.'
+  s.license = 'FreeBSD'
+
+  s.files        = `git ls-files`.split($/)
+  s.test_files   = s.files.grep(%r{^(test|spec|features)/})
+  s.require_path = 'lib'
+  s.has_rdoc     = true
+
+  s.required_ruby_version = '>= 1.8.6'
+
+  s.add_development_dependency "rake"
+  s.add_development_dependency "rdoc"
+  s.add_development_dependency "minitest"
+end

--- a/lib/cssmin.rb
+++ b/lib/cssmin.rb
@@ -53,59 +53,59 @@ module CSSMin
     css = input.is_a?(IO) ? input.read : input.dup.to_s
 
     # Remove comments.
-    css.gsub!(/\/\*[\s\S]*?\*\//, '')
+    css = css.gsub(/\/\*[\s\S]*?\*\//, '')
 
     # Compress all runs of whitespace to a single space to make things easier
     # to work with.
-    css.gsub!(/\s+/, ' ')
+    css = css.gsub(/\s+/, ' ')
 
     # Replace box model hacks with placeholders.
-    css.gsub!(/"\\"\}\\""/, '___BMH___')
+    css = css.gsub(/"\\"\}\\""/, '___BMH___')
 
     # Remove unnecessary spaces, but be careful not to turn "p :link {...}"
     # into "p:link{...}".
-    css.gsub!(/(?:^|\})[^\{:]+\s+:+[^\{]*\{/) do |match|
+    css = css.gsub(/(?:^|\})[^\{:]+\s+:+[^\{]*\{/) do |match|
       match.gsub(':', '___PSEUDOCLASSCOLON___')
     end
-    css.gsub!(/\s+([!\{\};:>+\(\)\],])/, '\1')
-    css.gsub!('___PSEUDOCLASSCOLON___', ':')
-    css.gsub!(/([!\{\}:;>+\(\[,])\s+/, '\1')
+    css = css.gsub(/\s+([!\{\};:>+\(\)\],])/, '\1')
+    css = css.gsub('___PSEUDOCLASSCOLON___', ':')
+    css = css.gsub(/([!\{\}:;>+\(\[,])\s+/, '\1')
 
     # Add missing semicolons.
-    css.gsub!(/([^;\}])\}/, '\1;}')
+    css = css.gsub(/([^;\}])\}/, '\1;}')
 
     # Replace 0(%, em, ex, px, in, cm, mm, pt, pc) with just 0.
-    css.gsub!(/([\s:])([+-]?0)(?:%|em|ex|px|in|cm|mm|pt|pc)/i, '\1\2')
+    css = css.gsub(/([\s:])([+-]?0)(?:%|em|ex|px|in|cm|mm|pt|pc)/i, '\1\2')
 
     # Replace 0 0 0 0; with 0.
-    css.gsub!(/:(?:0 )+0;/, ':0;')
+    css = css.gsub(/:(?:0 )+0;/, ':0;')
 
     # Replace background-position:0; with background-position:0 0;
-    css.gsub!('background-position:0;', 'background-position:0 0;')
+    css = css.gsub('background-position:0;', 'background-position:0 0;')
 
     # Replace 0.6 with .6, but only when preceded by : or a space.
-    css.gsub!(/(:|\s)0+\.(\d+)/, '\1.\2')
+    css = css.gsub(/(:|\s)0+\.(\d+)/, '\1.\2')
 
     # Convert rgb color values to hex values.
-    css.gsub!(/rgb\s*\(\s*([0-9,\s]+)\s*\)/) do |match|
+    css = css.gsub(/rgb\s*\(\s*([0-9,\s]+)\s*\)/) do |match|
       '#' << $1.scan(/\d+/).map{|n| n.to_i.to_s(16).rjust(2, '0') }.join
     end
 
     # Compress color hex values, making sure not to touch values used in IE
     # filters, since they would break.
-    css.gsub!(/([^"'=\s])(\s?)\s*#([0-9a-f])\3([0-9a-f])\4([0-9a-f])\5/i, '\1\2#\3\4\5')
+    css = css.gsub(/([^"'=\s])(\s?)\s*#([0-9a-f])\3([0-9a-f])\4([0-9a-f])\5/i, '\1\2#\3\4\5')
 
     # Remove empty rules.
-    css.gsub!(/[^\}]+\{;\}\n/, '')
+    css = css.gsub(/[^\}]+\{;\}\n/, '')
 
     # Re-insert box model hacks.
-    css.gsub!('___BMH___', '"\"}\""')
+    css = css.gsub('___BMH___', '"\"}\""')
 
     # Put the space back in for media queries
-    css.gsub!(/\band\(/, 'and (')
+    css = css.gsub(/\band\(/, 'and (')
 
     # Prevent redundant semicolons.
-    css.gsub!(/;+\}/, '}')
+    css = css.gsub(/;+\}/, '}')
 
     css.strip
   end


### PR DESCRIPTION
I'm currently using this gem in a Rail 2 application with the rails_xss gem, which monkey patches the bang String methods to explode upon use. These changes simply change the gsub! to gsub methods so CSSMin can be used with rails_xss.

I've also added a gemspec file to modernize things a little bit.
