### PR TITLE
Add special processing for transform-origin and mask-position

### DIFF
--- a/lib/cssmin.rb
+++ b/lib/cssmin.rb
@@ -83,6 +83,12 @@ module CSSMin
     # Replace background-position:0; with background-position:0 0;
     css = css.gsub('background-position:0;', 'background-position:0 0;')
 
+    # Replace transform-origin:0; with transform-origin:0 0;
+    css = css.gsub('transform-origin:0;', 'transform-origin:0 0;')
+
+    # Replace mask-position:0; with mask-position:0 0;
+    css = css.gsub('mask-position:0;', 'mask-position:0 0;')
+
     # Replace 0.6 with .6, but only when preceded by : or a space.
     css = css.gsub(/(:|\s)0+\.(\d+)/, '\1.\2')
 


### PR DESCRIPTION
As part of combining multiple zeroes into one, the properties of transform-origin and mask-position are incorrectly changed. This pull request adds special handling for these two cases by replacing **0** with **0 0**.
